### PR TITLE
Added box_url to config for precise64 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.hostname = "nooku.dev"
 
   config.vm.network :private_network, ip: "33.33.33.63"


### PR DESCRIPTION
When running vagrant up on a clean system, with vagrant just installed, a warning is output:

An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Couldn't open file /Users/oli/Sites/nooku-server/precise64

it appears that the precise64 box needs downloading, this can be achieved by adding the box_url to the Vagrantfile
