### PR TITLE
Enabled Xdebug extension

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -199,7 +199,7 @@ puphpet::ini { 'custom':
 # For enabling xdebug support for php-fpm, just uncomment the zend_extension directive and re-provision the VM.
 puphpet::ini { 'xdebug':
   value   => [
-  ';zend_extension=/usr/lib/php5/20100525/xdebug.so',
+  'zend_extension=/usr/lib/php5/20100525/xdebug.so',
   'xdebug.remote_autostart = 0',
   'xdebug.remote_connect_back = 1',
   'xdebug.remote_enable = 1',


### PR DESCRIPTION
The xdebug extension is disabled by default, given this is a development box, this should be enabled.
