### PR TITLE
Updated xdebug script to restart php-fpm rather than xginx

### DIFF
--- a/puppet/modules/scripts/files/scripts/xdebug
+++ b/puppet/modules/scripts/files/scripts/xdebug
@@ -59,7 +59,7 @@ class XDebug
             }
         }
 
-        `sudo /etc/init.d/nginx restart`;
+        `sudo /etc/init.d/php5-fpm restart`;
     }
 
     public function disable()
@@ -71,6 +71,6 @@ class XDebug
             }
         }
 
-        `sudo /etc/init.d/nginx restart`;
+        `sudo /etc/init.d/php5-fpm restart`;
     }
 }


### PR DESCRIPTION
FPM is what needs restarting, not xginx when enabling/disabling xdebug
